### PR TITLE
Update PMMLTranslator.java

### DIFF
--- a/src/main/java/ml/shifu/shifu/core/pmml/PMMLTranslator.java
+++ b/src/main/java/ml/shifu/shifu/core/pmml/PMMLTranslator.java
@@ -263,7 +263,6 @@ public class PMMLTranslator {
             origin.setTextContent(cval);
             inlineTable.withRows(new Row().withContent(origin).withContent(out));
             if(cval == ""){
-                default_value = dval;
                 missing_value = dval;
             }
         }


### PR DESCRIPTION
Correct mapping missing/empty string to 0.0 for categorical variables.

Previously, missing or empty string are mapped to 0.0 for categorical variable in PMML. But actually in SHIFU, empty string (such as "") is treat as a seperate bin and have its own value for categorical variables.  
