### PR TITLE
fix the iv bug in stats and flatten categorical values in when generating GBT tree

### DIFF
--- a/src/main/java/ml/shifu/shifu/core/binning/UpdateBinningInfoReducer.java
+++ b/src/main/java/ml/shifu/shifu/core/binning/UpdateBinningInfoReducer.java
@@ -278,62 +278,69 @@ public class UpdateBinningInfoReducer extends Reducer<IntWritable, BinningInfoWr
         double kurtosis = ColumnStatsCalculator.computeKurtosis(realCount, mean, aStdDev, sum, squaredSum, tripleSum,
                 quarticSum);
 
-        sb.append(key.get())
+        sb.append(key.get())                                        // column id
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(binBounString)
+                .append(binBounString)                              // column bins
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(binCountNeg))
+                .append(Arrays.toString(binCountNeg))               // bin count negative
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(binCountPos))
+                .append(Arrays.toString(binCountPos))               // bin count positive
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(new double[0]))
+                .append(Arrays.toString(new double[0]))             // deprecated
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(binPosRate))
+                .append(Arrays.toString(binPosRate))                // bin positive rate
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnCountMetrics == null ? "" : df.format(columnCountMetrics.getKs()))
+                .append(columnCountMetrics == null ? "" : df.format(columnCountMetrics.getKs()))   // KS
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnWeightMetrics == null ? "" : df.format(columnWeightMetrics.getIv()))
+                .append(columnCountMetrics == null ? "" : df.format(columnCountMetrics.getIv()))  // IV
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(df.format(max))
+                .append(df.format(max))                             // max
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(df.format(min))
+                .append(df.format(min))                             // min
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(df.format(mean))
+                .append(df.format(mean))                            // mean
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(df.format(stdDev))
+                .append(df.format(stdDev))                          // standard deviation
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnConfig.isCategorical() ? "C" : "N")
+                .append(columnConfig.isCategorical() ? "C" : "N")   // column type
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(df.format(mean))
+                .append(df.format(mean))                            // median value ?
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(missingCount)
+                .append(missingCount)                               // missing count
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(count)
+                .append(count)                                      // count
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(missingCount * 1.0d / count)
+                .append(missingCount * 1.0d / count)                // missing ratio
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(binWeightNeg))
+                .append(Arrays.toString(binWeightNeg))              // bin weighted negative
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(Arrays.toString(binWeightPos))
+                .append(Arrays.toString(binWeightPos))              // bin weighted positive
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnCountMetrics == null ? "" : columnCountMetrics.getWoe())
+                .append(columnCountMetrics == null ? "" : columnCountMetrics.getWoe())  // WOE
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnWeightMetrics == null ? "" : columnWeightMetrics.getWoe())
+                .append(columnWeightMetrics == null ? "" : columnWeightMetrics.getWoe()) // weighted WOE
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnWeightMetrics == null ? "" : columnWeightMetrics.getKs())
+                .append(columnWeightMetrics == null ? "" : columnWeightMetrics.getKs())  // weighted KS
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnCountMetrics == null ? "" : columnCountMetrics.getIv())
+                .append(columnWeightMetrics == null ? "" : columnWeightMetrics.getIv())  // weighted IV
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnCountMetrics == null ? Arrays.toString(new double[binSize + 1]) : columnCountMetrics
-                        .getBinningWoe().toString())
+                .append(columnCountMetrics == null ? Arrays.toString(new double[binSize + 1]) : columnCountMetrics.getBinningWoe().toString()) // bin WOE
                 .append(Constants.DEFAULT_DELIMITER)
-                .append(columnWeightMetrics == null ? Arrays.toString(new double[binSize + 1]) : columnWeightMetrics
-                        .getBinningWoe().toString()).append(Constants.DEFAULT_DELIMITER).append(skewness)
-                .append(Constants.DEFAULT_DELIMITER).append(kurtosis).append(Constants.DEFAULT_DELIMITER)
-                .append(totalCount).append(Constants.DEFAULT_DELIMITER).append(invalidCount)
-                .append(Constants.DEFAULT_DELIMITER).append(validNumCount).append(Constants.DEFAULT_DELIMITER)
-                .append(hyperLogLogPlus.cardinality()).append(Constants.DEFAULT_DELIMITER)
-                .append(limitedFrequentItems(fis));
+                .append(columnWeightMetrics == null ? Arrays.toString(new double[binSize + 1]) : columnWeightMetrics.getBinningWoe().toString()) // bin weighted WOE
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(skewness)                                   // skewness
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(kurtosis)                                   // kurtosis
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(totalCount)                                 // total count
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(invalidCount)                               // invalid count
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(validNumCount)                              // valid num count
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(hyperLogLogPlus.cardinality())              // cardinality
+                .append(Constants.DEFAULT_DELIMITER)
+                .append(limitedFrequentItems(fis));                 // frequent items
 
         outputValue.set(sb.toString());
         context.write(NullWritable.get(), outputValue);

--- a/src/main/java/ml/shifu/shifu/core/dtrain/dt/DTOutput.java
+++ b/src/main/java/ml/shifu/shifu/core/dtrain/dt/DTOutput.java
@@ -322,7 +322,13 @@ public class DTOutput extends BasicMasterInterceptor<DTMasterParams, DTWorkerPar
                     columnIndexNameMapping.put(columnConfig.getColumnNum(), columnConfig.getColumnName());
                 }
                 if(columnConfig.isCategorical() && CollectionUtils.isNotEmpty(columnConfig.getBinCategory())) {
-                    columnIndexCategoricalListMapping.put(columnConfig.getColumnNum(), columnConfig.getBinCategory());
+                    // There is 16k limitation when using writeUTF() function.
+                    // Flatten the binCategories to avoid too long categories
+                    List<String> binCategories = new ArrayList<String>();
+                    for ( String category : columnConfig.getBinCategory() ) {
+                        binCategories.addAll(CommonUtils.flattenCatValGrp(category));
+                    }
+                    columnIndexCategoricalListMapping.put(columnConfig.getColumnNum(), binCategories);
                 }
 
                 if(columnConfig.isNumerical() && columnConfig.getMean() != null) {

--- a/src/test/java/ml/shifu/shifu/model/GBTModelSpecValidateTest.java
+++ b/src/test/java/ml/shifu/shifu/model/GBTModelSpecValidateTest.java
@@ -1,0 +1,56 @@
+package ml.shifu.shifu.model;
+
+import ml.shifu.shifu.core.dtrain.dt.IndependentTreeModel;
+import ml.shifu.shifu.core.dtrain.dt.Node;
+import ml.shifu.shifu.core.dtrain.dt.TreeNode;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Created by zhanhu on 5/23/17.
+ */
+public class GBTModelSpecValidateTest {
+
+    @Test
+    public void validateCAMGBT() throws IOException {
+        Assert.assertTrue(validate("src/test/resources/dttest/model/model_cam.gbt"));
+    }
+
+    //@Test
+    public void validateShifuGBTModel() throws IOException {
+        Assert.assertTrue(validate("~/Downloads/model0.gbt"));
+    }
+
+    //@Test
+    public void validateShifuGBT2Model() throws IOException {
+        Assert.assertTrue(validate("src/test/resources/dttest/model0.gbt"));
+    }
+
+
+    private boolean validate(String modelLoc) throws IOException {
+        IndependentTreeModel treeModel = IndependentTreeModel.loadFromStream(
+                new FileInputStream(modelLoc));
+        boolean status = true;
+        for (TreeNode tree : treeModel.getTrees()) {
+            Node node = tree.getNode();
+            status = status && validate(node, treeModel.getNumNameMapping());
+        }
+        return status;
+    }
+
+    private boolean validate(Node node, Map<Integer, String> numNameMapping) {
+        if ( node != null && !node.isRealLeaf()) {
+            Integer splitColumnNum = node.getSplit().getColumnNum();
+            if ( !numNameMapping.containsKey(splitColumnNum) ) {
+                return false;
+            } else {
+                return validate(node.getLeft(), numNameMapping) && validate(node.getRight(), numNameMapping);
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
1. fix a bug in setting IV value - weighted iv is miss-used as iv
2. flatten categorical variables when generating GBT tree to avoid too long categorical value limitcation(16k)