### PR TITLE
Fixed bug java.lang.NullPointerException when generate pmml

### DIFF
--- a/src/main/java/ml/shifu/shifu/core/pmml/TreeEnsemblePMMLTranslator.java
+++ b/src/main/java/ml/shifu/shifu/core/pmml/TreeEnsemblePMMLTranslator.java
@@ -55,12 +55,21 @@ public class TreeEnsemblePMMLTranslator extends PMMLTranslator {
         this.miningSchemaCreator = miningSchemaCreator;
     }
 
+    @Override
+    public PMML build(List<BasicML> basicMLs) {
+        if(basicMLs.isEmpty()) {
+            LOG.error("basic length should not be null");
+            return null;
+        }
+        return build(basicMLs.get(0));
+    }
+
     public PMML build(BasicML basicML) {
         PMML pmml = new PMML();
 
         Header header = new Header();
         pmml.setHeader(header);
-        header.setCopyright(" Copyright [2013-2017] PayPal Software Foundation\n" + "\n"
+        header.setCopyright(" Copyright [2013-2019] PayPal Software Foundation\n" + "\n"
                 + " Licensed under the Apache License, Version 2.0 (the \"License\");\n"
                 + " you may not use this file except in compliance with the License.\n"
                 + " You may obtain a copy of the License at\n" + "\n"


### PR DESCRIPTION
Bug:
shifu export -t pmml
2019-12-10 10:20:05: INFO BasicModelProcessor [main] - ModelConfig Validation - OK
2019-12-10 10:20:05: INFO BasicModelProcessor [main] - Training Data Soure Location: HDFS
2019-12-10 10:20:05: INFO ModelConfig [main] - 'dataSet::categoricalColumnHashSeedConfFile' is not set and default categoricalColumnHashSeedConfFile: columns/categorical.hash.seed.conf is not found, no categorical hash seed files.
2019-12-10 10:20:05: WARN ModelConfig [main] - 'dataSet::hybridColumnNameFile' is not set and default hybridColumnNameFile: columns/hybrid.column.names is not found, no hybrid configs.
2019-12-10 10:20:05: INFO BasicModelProcessor [main] - Saving ColumnConfig...
2019-12-10 10:20:07: INFO ExportModelProcessor [main] -             Start to generate pmmls/cam20_ref_driver17_shortwin_gbt0.pmml
2019-12-10 10:20:07: ERROR ShifuCLI [main] - Error in running, please check the stack, msg:java.lang.NullPointerException
java.lang.NullPointerException
                at ml.shifu.shifu.core.pmml.PMMLTranslator.build(PMMLTranslator.java:120)
                at ml.shifu.shifu.core.processor.ExportModelProcessor.run(ExportModelProcessor.java:171)
                at ml.shifu.shifu.ShifuCLI.exportModel(ShifuCLI.java:612)
                at ml.shifu.shifu.ShifuCLI.main(ShifuCLI.java:377)
Error! Please check the log file for more information.
 