### PR TITLE
Fix duplicated column name issue

### DIFF
--- a/src/main/java/ml/shifu/shifu/util/CommonUtils.java
+++ b/src/main/java/ml/shifu/shifu/util/CommonUtils.java
@@ -658,6 +658,17 @@ public final class CommonUtils {
         return calculateHeaders(pigHeaderStr, delimiter, isFull);
     }
 
+    /**
+     * Return header column array from header string.
+     *
+     * @param pigHeaderStr
+     *            header string
+     * @param delimiter
+     *            the delimiter of headers
+     * @param isFull
+     *            if full header name including name space
+     * @return headers array
+     */
     public static String[] calculateHeaders(String pigHeaderStr, String delimiter, boolean isFull) {
         List<String> headerList = new ArrayList<String>();
         Set<String> headerSet = new HashSet<String>();

--- a/src/main/java/ml/shifu/shifu/util/HDFSUtils.java
+++ b/src/main/java/ml/shifu/shifu/util/HDFSUtils.java
@@ -70,12 +70,19 @@ public final class HDFSUtils {
     }
 
     /**
+     * Get HDFS FileSystem.
+     */
+    public static FileSystem getFS() {
+        return getFS(null);
+    }
+
+    /**
      * Get HDFS FileSystem according the Path
      * @param path - file path to access
      * @return file system for specified path
      */
     public static FileSystem getFS(Path path) {
-        String host = (path.toUri() == null || StringUtils.isBlank(path.toUri().getHost())) ?
+        String host = (path == null || path.toUri() == null || StringUtils.isBlank(path.toUri().getHost())) ?
                 DEFAULT_HOST : path.toUri().getHost();
         FileSystem fs = hdfs.getOrDefault(host, null);
         if (fs == null) {

--- a/src/test/java/ml/shifu/shifu/util/CommonUtilsTest.java
+++ b/src/test/java/ml/shifu/shifu/util/CommonUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package ml.shifu.shifu.util;
 
+import com.google.common.collect.Sets;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -23,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -477,6 +479,21 @@ public class CommonUtilsTest {
         Assert.assertEquals(CommonUtils.trimTag(" "), "");
         Assert.assertEquals(CommonUtils.trimTag(null), "");
         Assert.assertEquals(CommonUtils.trimTag("1.0B"), "1.0B");
+    }
+
+    @Test
+    public void testGetUniqueName() {
+        Assert.assertNull(CommonUtils.getUniqueName(null, null));
+        Assert.assertEquals(CommonUtils.getUniqueName(null, "abc"), "abc");
+        Assert.assertEquals(CommonUtils.getUniqueName(Collections.singleton("a"), "abc"), "abc");
+        Assert.assertEquals(CommonUtils.getUniqueName(Collections.singleton("abc"), "abc"), "abc_1");
+        Assert.assertEquals(CommonUtils.getUniqueName(Sets.newHashSet("abc", "abc_1"), "abc"), "abc_2");
+    }
+
+    @Test
+    public void testCalculateHeaders() {
+        Assert.assertEquals(new String[]{"a", "a_dup1", "a_dup2", "a_dup3"}, CommonUtils.calculateHeaders("a,a,a,a", ",", false));
+        Assert.assertEquals(new String[]{"a_dup2", "a", "a_dup2_1", "a_dup3"}, CommonUtils.calculateHeaders("a_dup2,a,a,a", ",", false));
     }
 
     @AfterClass


### PR DESCRIPTION
## Description
### 1. Fix duplicated column name which exists in raw data header.
This change will affect `shifu init` action.
**Old logic**: if the raw data's header have duplicated column name, it will add `_[columnIndex]` suffix to avoid column duplicated. For example, raw data header is:
```
0: name
1: name_3
2. name_dup3
3: name
```

Because the column name of index 0 and 3 are `name`, so we changed the index 3 column to `name_3`:
```
0: name
1: name_3
2: name_dup3
3: name_3
```

But the index 1 and 3 are now conflict.

**New logic**: we change the duplicated name to add `_dup[columnIndex]` suffix. If it is still conflict with some column, we will change it to`_dup[columnIndex]_1`, `_dup[columnIndex]_2`, etc. With above example, it will change the column name to:
```
0: name
1: name_3
2: name_dup3
3: name_dup3_1
```

### 2. Fix duplicated column name due to multi-segment feature.
This change will affect `shifu stas` action.
**Old logic**: we will add suffix for segement column with `_[segementIndex]`. For example, column names are below:
```
0: name_1
1: name
2: name_seg1
```

After adding segment columns, the column name will be changed to:
```
0: name_1
1: name
2: name_seg1
3: name_1_1
4: name_1
5: name_seg1_1
```

We can find that the index 0 and 4 are conflict with `name_1`.

**New logic**: we will add suffix for segement column with `_seg[segmentIndex]`. If it still conflict with other columns, it will be changed to `_seg[segmentIndex]_1`, `_seg[segmentIndex]_2`, etc. With above example, it will change the columns to:
```
0: name_1
1: name
2: name_seg1
3: name_1_seg1
4: name_seg1_1
5: name_seg1_seg1
```

### 3. Fix a compatibility issue for shifu-tensorflow.
Add method `HDFSUtils.getFS()`, becuase shifu-tensorflow depends on this method.

## Tests
1. Unit tests added.
2. Manually tested `shifu new`, `shifu init`, `shifu stats` and `shifu norm`.
