### PR TITLE
Fix segment data missing in shifu norm

### DIFF
--- a/src/main/java/ml/shifu/shifu/util/updater/BasicUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/BasicUpdater.java
@@ -1,6 +1,7 @@
 package ml.shifu.shifu.util.updater;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,8 @@ public class BasicUpdater {
     private final static Logger LOG = LoggerFactory.getLogger(BasicUpdater.class);
 
     protected ModelConfig modelConfig;
+    protected List<ColumnConfig> columnConfigList;
+    protected Map<String, ColumnConfig> columnConfigMap;
 
     protected String targetColumnName;
     protected String weightColumnName;
@@ -47,13 +50,17 @@ public class BasicUpdater {
 
     protected boolean isForSegs;
     protected List<String> segs;
+    // The column amount in original data.
+    protected int originalColumnAmount;
 
-    public BasicUpdater(ModelConfig modelConfig, int mtlIndex) throws IOException {
+    public BasicUpdater(ModelConfig modelConfig, List<ColumnConfig> columnConfigList, int mtlIndex) throws IOException {
         this.modelConfig = modelConfig;
+        this.columnConfigList = columnConfigList;
         this.segs = modelConfig.getSegmentFilterExpressions();
         this.isForSegs = (this.segs.size() > 0);
         this.mtlIndex = mtlIndex;
         this.modelConfig.setMtlIndex(mtlIndex);
+        initColumnConfigMapForSegs();
 
         this.targetColumnName = modelConfig.isMultiTask() ? modelConfig.getMultiTaskTargetColumnNames().get(mtlIndex)
                 : modelConfig.getTargetColumnName();
@@ -97,11 +104,7 @@ public class BasicUpdater {
         if(CollectionUtils.isNotEmpty(columnNames)) {
             for(String column: columnNames) {
                 nsColumns.add(new NSColumn(column));
-                if(this.isForSegs) {
-                    for(int i = 0; i < segs.size(); i++) {
-                        nsColumns.add(new NSColumn(column + "_" + (i + 1)));
-                    }
-                }
+                addSegColumns(nsColumns, column);
             }
         }
         return nsColumns;
@@ -163,23 +166,23 @@ public class BasicUpdater {
         }
     }
 
-    public static BasicUpdater getUpdater(ModelConfig modelConfig, ModelInspector.ModelStep step, int mtlIndex)
+    public static BasicUpdater getUpdater(ModelConfig modelConfig, List<ColumnConfig> columnConfigList, ModelInspector.ModelStep step, int mtlIndex)
             throws IOException {
         BasicUpdater updater = null;
         switch(step) {
             case INIT:
             case STATS:
             case NORMALIZE:
-                updater = new BasicUpdater(modelConfig, mtlIndex);
+                updater = new BasicUpdater(modelConfig, columnConfigList, mtlIndex);
                 break;
             case VARSELECT:
-                updater = new VarSelUpdater(modelConfig, mtlIndex);
+                updater = new VarSelUpdater(modelConfig, columnConfigList, mtlIndex);
                 break;
             case TRAIN:
-                updater = new TrainUpdater(modelConfig, mtlIndex);
+                updater = new TrainUpdater(modelConfig, columnConfigList, mtlIndex);
                 break;
             default:
-                updater = new VoidUpdater(modelConfig, mtlIndex);
+                updater = new VoidUpdater(modelConfig, columnConfigList, mtlIndex);
                 break;
         }
         return updater;
@@ -198,5 +201,46 @@ public class BasicUpdater {
      */
     public void setMtlIndex(int mtlIndex) {
         this.mtlIndex = mtlIndex;
+    }
+
+    /**
+     * Init the column config map if segment exists.
+     */
+    private void initColumnConfigMapForSegs() {
+        if (isForSegs) {
+            int totalColumnAmount = columnConfigList.size();
+            originalColumnAmount = totalColumnAmount / (segs.size() + 1);
+            LOG.info("Init column config map in updater, totalColumnAmount={}, originalColumnAmount={}, segAmount={}.", totalColumnAmount,
+                originalColumnAmount, segs.size());
+            columnConfigMap = new HashMap<>(columnConfigList.size());
+            for (ColumnConfig config : columnConfigList) {
+                columnConfigMap.put(config.getColumnName(), config);
+            }
+        }
+    }
+
+    /**
+     * Add segment column names to the set.
+     *
+     * @param segColumnSet is the set which will hold segment column names.
+     * @param columnName   is the original column name (non-segment column).
+     */
+    private void addSegColumns(Set<NSColumn> segColumnSet, String columnName) {
+        // Only do it when segment exists.
+        if (this.isForSegs) {
+            ColumnConfig originalColumnConfig = columnConfigMap.get(columnName);
+            // We need make sure the original column exist and the bound is within [0, originalColumnAmount).
+            if (originalColumnConfig == null && originalColumnConfig.getColumnNum() < originalColumnAmount) {
+                return;
+            }
+            for (int i = 0; i < segs.size(); i++) {
+                // Calculate the segment's column config number(index), and put it into the set.
+                int segColumnConfigNum = originalColumnConfig.getColumnNum() + (i + 1) * originalColumnAmount;
+                ColumnConfig segColumnConfig = columnConfigList.get(segColumnConfigNum);
+                segColumnSet.add(new NSColumn(segColumnConfig.getColumnName()));
+                LOG.debug("Add {}({})'s segment {}({}).", columnName, originalColumnConfig.getColumnNum(), segColumnConfig.getColumnName(),
+                    segColumnConfigNum);
+            }
+        }
     }
 }

--- a/src/main/java/ml/shifu/shifu/util/updater/ColumnConfigUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/ColumnConfigUpdater.java
@@ -51,9 +51,9 @@ public class ColumnConfigUpdater {
             ModelInspector.ModelStep step, boolean directVoidCall, int mtlIndex) throws IOException {
         BasicUpdater updater = null;
         if(directVoidCall) {
-            updater = new VoidUpdater(modelConfig, mtlIndex);
+            updater = new VoidUpdater(modelConfig, columnConfigList, mtlIndex);
         } else {
-            updater = BasicUpdater.getUpdater(modelConfig, step, mtlIndex);
+            updater = BasicUpdater.getUpdater(modelConfig, columnConfigList, step, mtlIndex);
         }
 
         for(ColumnConfig config: columnConfigList) {

--- a/src/main/java/ml/shifu/shifu/util/updater/TrainUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/TrainUpdater.java
@@ -1,6 +1,7 @@
 package ml.shifu.shifu.util.updater;
 
 import java.io.IOException;
+import java.util.List;
 import ml.shifu.shifu.column.NSColumn;
 import ml.shifu.shifu.column.NSColumnUtils;
 import ml.shifu.shifu.container.obj.ColumnConfig;
@@ -14,8 +15,8 @@ import org.apache.commons.collections.CollectionUtils;
  */
 public class TrainUpdater extends BasicUpdater {
 
-    public TrainUpdater(ModelConfig modelConfig, int mtlIndex) throws IOException {
-        super(modelConfig, mtlIndex);
+    public TrainUpdater(ModelConfig modelConfig, List<ColumnConfig> columnConfigList, int mtlIndex) throws IOException {
+        super(modelConfig, columnConfigList, mtlIndex);
     }
 
     @Override

--- a/src/main/java/ml/shifu/shifu/util/updater/VarSelUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/VarSelUpdater.java
@@ -16,8 +16,8 @@ import org.apache.commons.collections.CollectionUtils;
  */
 public class VarSelUpdater extends BasicUpdater {
 
-    public VarSelUpdater(ModelConfig modelConfig, int mtlIndex) throws IOException {
-        super(modelConfig, mtlIndex);
+    public VarSelUpdater(ModelConfig modelConfig, List<ColumnConfig> columnConfigList, int mtlIndex) throws IOException {
+        super(modelConfig, columnConfigList, mtlIndex);
     }
 
     @Override

--- a/src/main/java/ml/shifu/shifu/util/updater/VoidUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/VoidUpdater.java
@@ -1,5 +1,6 @@
 package ml.shifu.shifu.util.updater;
 
+import java.util.List;
 import ml.shifu.shifu.container.obj.ColumnConfig;
 import ml.shifu.shifu.container.obj.ModelConfig;
 
@@ -10,8 +11,8 @@ import java.io.IOException;
  */
 public class VoidUpdater extends BasicUpdater {
 
-    public VoidUpdater(ModelConfig modelConfig, int mtlIndex) throws IOException {
-        super(modelConfig, mtlIndex);
+    public VoidUpdater(ModelConfig modelConfig, List<ColumnConfig> columnConfigList, int mtlIndex) throws IOException {
+        super(modelConfig, columnConfigList, mtlIndex);
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR is a bug fix for this one: https://github.com/ShifuML/shifu/pull/732.

We changed segment column's name from `name_1` to `name_seg1` in `stats` step. But we didn't change the logic in `norm` step, so we will find empty segment data in normalized data. 

For example, the header is:
```
target_column|column_1|column_2|column_1_seg1|column_2_seg1
```

We will get data like below (with the bug):
```
1|0.5|0.1|||1.0
```

But we want to get data like:
```
1|0.5|0.1|0.2|-0.1|1.0
```

Therefore, I changed the logic in `norm` step and any other step which will use `BasicUpdater`.

## Tests
I manually tested it with large data. It generated right data. For unit test, I didn't find related UT for `BasicUpdater`, I think I can add it later.