### PR TITLE
Add column config cache for UDFs

### DIFF
--- a/src/main/java/ml/shifu/shifu/udf/AbstractTrainerUDF.java
+++ b/src/main/java/ml/shifu/shifu/udf/AbstractTrainerUDF.java
@@ -15,6 +15,8 @@
  */
 package ml.shifu.shifu.udf;
 
+import java.util.HashMap;
+import java.util.Map;
 import ml.shifu.guagua.util.NumberFormatUtils;
 import ml.shifu.shifu.container.obj.ColumnConfig;
 import ml.shifu.shifu.container.obj.ModelConfig;
@@ -41,6 +43,9 @@ import java.util.Set;
  * It will load and host @ModelConfig and @ColumnConfig, and find target column id
  */
 public abstract class AbstractTrainerUDF<T> extends EvalFunc<T> {
+
+    // This cache aims to decrease the memory usage when column config is very large.
+    private static Map<String, List<ColumnConfig>> columnConfigCache = new HashMap<>(1);
 
     protected ModelConfig modelConfig;
     protected List<ColumnConfig> columnConfigList;
@@ -92,7 +97,7 @@ public abstract class AbstractTrainerUDF<T> extends EvalFunc<T> {
             }
         }
 
-        columnConfigList = CommonUtils.loadColumnConfigList(pathColumnConfig, sourceType);
+        columnConfigList = loadColumnConfigList(pathColumnConfig, sourceType);
         tagColumnNum = CommonUtils.getTargetColumnNum(columnConfigList);
 
         if(modelConfig != null && modelConfig.getPosTags() != null) {
@@ -114,6 +119,25 @@ public abstract class AbstractTrainerUDF<T> extends EvalFunc<T> {
         }
 
         this.hasCandidates = CommonUtils.hasCandidateColumns(this.columnConfigList);
+    }
+
+    /**
+     * Load column config list.
+     *
+     * @param pathColumnConfig is the column config file path.
+     * @param sourceType       is the source type: HDFS, LOCAL, etc.
+     * @return the column config list.
+     * @throws IOException if load column config failed.
+     */
+    private static synchronized List<ColumnConfig> loadColumnConfigList(String pathColumnConfig, SourceType sourceType) throws IOException {
+        // Return the cached column config if it exists. This action will avoid loading same column config file more times.
+        String key = pathColumnConfig + "," + sourceType;
+        List<ColumnConfig> cachedColumnConfigList = columnConfigCache.get(key);
+        if (cachedColumnConfigList == null) {
+            cachedColumnConfigList = CommonUtils.loadColumnConfigList(pathColumnConfig, sourceType);
+            columnConfigCache.put(key, cachedColumnConfigList);
+        }
+        return cachedColumnConfigList;
     }
 
     /**

--- a/src/test/java/ml/shifu/shifu/udf/NormalizeUDFTest.java
+++ b/src/test/java/ml/shifu/shifu/udf/NormalizeUDFTest.java
@@ -113,4 +113,16 @@ public class NormalizeUDFTest {
         Assert.assertEquals(5, output.size());
         Assert.assertEquals("(1,-3.3745382,-4.0,-3.697376,2.1)", output.toString());
     }
+
+    @Test
+    public void testColumnConfigCache() throws Exception {
+        String modelConfigPath = "src/test/resources/example/cancer-judgement/ModelStore/ModelSet1/ModelConfig.json";
+        String columnConfigPath = "src/test/resources/example/cancer-judgement/ModelStore/ModelSet1/ColumnConfig.json";
+        String compactColumnConfigPath = "src/test/resources/example/cancer-judgement/ModelStore/ModelSet1/ColumnConfigCompact.json";
+        NormalizeUDF normUDF1 = new NormalizeUDF("LOCAL", modelConfigPath, columnConfigPath);
+        NormalizeUDF normUDF2 = new NormalizeUDF("LOCAL", modelConfigPath, columnConfigPath);
+        NormalizeUDF normUDF3 = new NormalizeUDF("LOCAL", modelConfigPath, compactColumnConfigPath);
+        Assert.assertTrue(normUDF1.columnConfigList == normUDF2.columnConfigList);
+        Assert.assertFalse(normUDF1.columnConfigList == normUDF3.columnConfigList);
+    }
 }


### PR DESCRIPTION
## Description
Issue: https://github.com/ShifuML/shifu/issues/738

This change provides cache for column config in UDFs. Each UDF instance will load column config. It costs much memory if the column config is large.

## Tests
Unit test added.