### PR TITLE
Fix segment issue in shifu init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .settings
 .DS_Store
 test-output
+logs

--- a/src/main/java/ml/shifu/shifu/container/obj/ColumnConfig.java
+++ b/src/main/java/ml/shifu/shifu/container/obj/ColumnConfig.java
@@ -74,6 +74,11 @@ public class ColumnConfig {
      */
     private Boolean finalSelect = Boolean.FALSE;
 
+    /**
+     * This column is a segment column or not.
+     */
+    private Boolean isSegment = Boolean.FALSE;
+
     // in some hybrid threshold, some values like -100 is also category, try to set a threshold like 0, if value<0 would
     // be treated as categorical features, if not set, by default threshold is min double value, which means all value <
     // min can be set to categorical, which is all double value is not categorical, only works in Hybrid column type
@@ -152,6 +157,14 @@ public class ColumnConfig {
 
     public void setFinalSelect(Boolean finalSelect) {
         this.finalSelect = finalSelect;
+    }
+
+    public Boolean isSegment() {
+        return isSegment;
+    }
+
+    public void setSegment(Boolean isSegment) {
+        this.isSegment = isSegment;
     }
 
     public void setColumnName(String columnName) {
@@ -495,6 +508,7 @@ public class ColumnConfig {
         other.setColumnType(columnType);
         other.setColumnFlag(columnFlag);
         other.setFinalSelect(finalSelect);
+        other.setSegment(isSegment);
         other.setColumnStats(columnStats);
         other.setColumnBinning(columnBinning);
         // other.setCorrArray(corrArray);
@@ -555,6 +569,7 @@ public class ColumnConfig {
                 output.writeUTF(sampleValue);
             }
         }
+        output.writeBoolean(isSegment);
     }
 
     /**
@@ -580,5 +595,6 @@ public class ColumnConfig {
         for (int i = 0; i < size; i++) {
             sampleValues.add(input.readUTF());
         }
+        isSegment = input.readBoolean();
     }
 }

--- a/src/main/java/ml/shifu/shifu/core/processor/stats/MapReducerStatsWorker.java
+++ b/src/main/java/ml/shifu/shifu/core/processor/stats/MapReducerStatsWorker.java
@@ -664,6 +664,7 @@ public class MapReducerStatsWorker extends AbstractStatsExecutor {
                     config.setColumnType(basicConfig.getColumnType());
                     config.setColumnFlag(basicConfig.getColumnFlag() == ColumnFlag.Target ? ColumnFlag.Meta
                             : basicConfig.getColumnFlag());
+                    config.setSegment(true);
                     // If we have 30 features and column number is 31, we got column name "columnname_seg1"
                     String columnName = basicConfig.getColumnName() + "_seg" + (columnNum / ccInitSize);
                     if (columnNames.contains(columnName)) {

--- a/src/main/java/ml/shifu/shifu/util/updater/BasicUpdater.java
+++ b/src/main/java/ml/shifu/shifu/util/updater/BasicUpdater.java
@@ -208,14 +208,16 @@ public class BasicUpdater {
      */
     private void initColumnConfigMapForSegs() {
         if (isForSegs) {
-            int totalColumnAmount = columnConfigList.size();
-            originalColumnAmount = totalColumnAmount / (segs.size() + 1);
-            LOG.info("Init column config map in updater, totalColumnAmount={}, originalColumnAmount={}, segAmount={}.", totalColumnAmount,
-                originalColumnAmount, segs.size());
+            originalColumnAmount = 0;
             columnConfigMap = new HashMap<>(columnConfigList.size());
             for (ColumnConfig config : columnConfigList) {
                 columnConfigMap.put(config.getColumnName(), config);
+                if (config.isSegment() != null && !config.isSegment()) {
+                    originalColumnAmount++;
+                }
             }
+            LOG.info("Init column config map in updater, totalColumnAmount={}, originalColumnAmount={}, segAmount={}.",
+                columnConfigList.size(), originalColumnAmount, segs.size());
         }
     }
 
@@ -236,6 +238,9 @@ public class BasicUpdater {
             for (int i = 0; i < segs.size(); i++) {
                 // Calculate the segment's column config number(index), and put it into the set.
                 int segColumnConfigNum = originalColumnConfig.getColumnNum() + (i + 1) * originalColumnAmount;
+                if (segColumnConfigNum >= columnConfigList.size()) {
+                    break;
+                }
                 ColumnConfig segColumnConfig = columnConfigList.get(segColumnConfigNum);
                 segColumnSet.add(new NSColumn(segColumnConfig.getColumnName()));
                 LOG.debug("Add {}({})'s segment {}({}).", columnName, originalColumnConfig.getColumnNum(), segColumnConfig.getColumnName(),


### PR DESCRIPTION
## Description
This fix is a following change of https://github.com/ShifuML/shifu/pull/739.

We cannot calculate non-segment column amount by below expression. Because we don't have any segment column in config when we do `shifu init`.
```
nonSegmentColumnAmount = columnAmountInConfig / (1+segmentSize)
```

Therefore, I add a new field in column config to mark the column as segment or not.

## Tests
I manually tested `init`, `stats`, `norm` and `train`.