### PR TITLE
Add Chaos Injection Ability

### DIFF
--- a/src/main/java/ml/shifu/shifu/ShifuCLI.java
+++ b/src/main/java/ml/shifu/shifu/ShifuCLI.java
@@ -60,6 +60,9 @@ import ml.shifu.shifu.core.processor.TrainModelProcessor;
 import ml.shifu.shifu.core.processor.VarSelectModelProcessor;
 import ml.shifu.shifu.exception.ShifuException;
 
+import static ml.shifu.shifu.util.Constants.CHAOS_COLUMNS;
+import static ml.shifu.shifu.util.Constants.CHAOS_TYPE;
+
 /**
  * ShifuCLI class is the MAIN class for whole project
  * It will read and analysis the parameters from command line
@@ -121,6 +124,8 @@ public class ShifuCLI {
     private static final String SCORE = "score";
     private static final String CONFMAT = "confmat";
     private static final String PERF = "perf";
+    private static final String STABILITY = "stab";
+
     private static final String NORM = "norm";
     private static final String NOSORT = "nosort";
     private static final String REF = "ref";
@@ -363,6 +368,16 @@ public class ShifuCLI {
                         // run perfermance
                         runEvalPerf(cmd.getOptionValue(PERF));
                         log.info("Finish run performance maxtrix with eval set {}.", cmd.getOptionValue(PERF));
+                    } else if(cmd.hasOption(STABILITY)) {
+                        // run perfermance
+                        if(cmd.hasOption(CHAOS_TYPE)) {
+                            params.put(CHAOS_TYPE, cmd.getOptionValue(CHAOS_TYPE));
+                        }
+                        if(cmd.hasOption(CHAOS_COLUMNS)) {
+                            params.put(CHAOS_COLUMNS, cmd.getOptionValue(CHAOS_COLUMNS));
+                        }
+                        runEvalStability(cmd.getOptionValue(STABILITY), params);
+                        log.info("Finish run performance maxtrix with eval set {}.", cmd.getOptionValue(PERF));
                     } else if(cmd.hasOption(LIST)) {
                         // list all evaluation sets
                         listEvalSet();
@@ -598,6 +613,11 @@ public class ShifuCLI {
 
     private static int runEvalPerf(String evalSetNames) throws Exception {
         EvalModelProcessor p = new EvalModelProcessor(EvalStep.PERF, evalSetNames);
+        return p.run();
+    }
+
+    private static int runEvalStability(String evalSetNames, Map<String, Object> params) throws Exception {
+        EvalModelProcessor p = new EvalModelProcessor(EvalStep.STAB, evalSetNames, params);
         return p.run();
     }
 

--- a/src/main/java/ml/shifu/shifu/ShifuCLI.java
+++ b/src/main/java/ml/shifu/shifu/ShifuCLI.java
@@ -788,6 +788,9 @@ public class ShifuCLI {
         Option opt_score = OptionBuilder.hasOptionalArg().create(SCORE);
         Option opt_confmat = OptionBuilder.hasArg().create(CONFMAT);
         Option opt_perf = OptionBuilder.hasArg().create(PERF);
+        Option opt_stab = OptionBuilder.hasArg(false).create(STABILITY);
+        Option opt_chaos_type = OptionBuilder.hasArg().create(CHAOS_TYPE);
+        Option opt_chaos_cols = OptionBuilder.hasArg().create(CHAOS_COLUMNS);
         Option opt_norm = OptionBuilder.hasArg().create(NORM);
         Option opt_eval = OptionBuilder.hasArg(false).create(EVAL_CMD);
         Option opt_init = OptionBuilder.hasArg(false).create(INIT_CMD);
@@ -820,6 +823,9 @@ public class ShifuCLI {
         opts.addOption(opt_type);
         opts.addOption(opt_run);
         opts.addOption(opt_perf);
+        opts.addOption(opt_stab);
+        opts.addOption(opt_chaos_type);
+        opts.addOption(opt_chaos_cols);
         opts.addOption(opt_norm);
         opts.addOption(opt_model);
         opts.addOption(opt_concise);
@@ -914,6 +920,8 @@ public class ShifuCLI {
         System.out.println("\teval -confmat <EvalSetName>             Compute the TP/FP/TN/FN based on scoring.");
         System.out
                 .println("\teval -perf <EvalSetName>                Calculate the model performance based on confmat.");
+        System.out.println("\teval -stab <EvalSetName> -type <chaosType> -cols <column names list join with ','>  " +
+                "Score evaluation dataset with injection on specific columns.");
         System.out.println("\teval -audit [-n <#numofrecords>]        Score eval data and generate audit dataset.");
         System.out.println(
                 "\texport [-t pmml|columnstats|woemapping|bagging|baggingpmml|corr|woe|ume|baggingume] [-c] [-vars var1,var1] [-ivr <ratio>] [-bic <bic>] [-name <modelName>]");

--- a/src/main/java/ml/shifu/shifu/core/processor/EvalModelProcessor.java
+++ b/src/main/java/ml/shifu/shifu/core/processor/EvalModelProcessor.java
@@ -463,6 +463,7 @@ public class EvalModelProcessor extends BasicModelProcessor implements Processor
             paramsMap.put(CHAOS_COLUMNS, this.params.get(CHAOS_COLUMNS).toString());
             pigScript = "scripts/EvalChaosScore.pig";
         }
+        LOG.info("run dist score with pigScript {}, parameters: {}", pigScript, paramsMap.toString());
 
         try {
             PigExecutor.getExecutor().submitJob(modelConfig, pathFinder.getScriptPath(pigScript), paramsMap,

--- a/src/main/java/ml/shifu/shifu/core/processor/EvalModelProcessor.java
+++ b/src/main/java/ml/shifu/shifu/core/processor/EvalModelProcessor.java
@@ -20,18 +20,11 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
+import ml.shifu.shifu.core.stability.ChaosType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -69,6 +62,9 @@ import ml.shifu.shifu.util.Environment;
 import ml.shifu.shifu.util.HdfsPartFile;
 import ml.shifu.shifu.util.ModelSpecLoaderUtils;
 
+import static ml.shifu.shifu.util.Constants.CHAOS_COLUMNS;
+import static ml.shifu.shifu.util.Constants.CHAOS_TYPE;
+
 /**
  * EvalModelProcessor class
  */
@@ -83,7 +79,7 @@ public class EvalModelProcessor extends BasicModelProcessor implements Processor
      * Step for evaluation
      */
     public enum EvalStep {
-        LIST, NEW, DELETE, RUN, PERF, SCORE, AUDIT, CONFMAT, NORM, GAINCHART;
+        LIST, NEW, DELETE, RUN, PERF, STAB, SCORE, AUDIT, CONFMAT, NORM, GAINCHART;
     }
 
     public static final String NOSORT = "NOSORT";
@@ -181,6 +177,9 @@ public class EvalModelProcessor extends BasicModelProcessor implements Processor
                     break;
                 case SCORE:
                     runScore(getEvalConfigListFromInput());
+                    break;
+                case STAB:
+                    runStability(getEvalConfigListFromInput());
                     break;
                 case AUDIT:
                     runGenAudit(getEvalConfigListFromInput());
@@ -459,6 +458,12 @@ public class EvalModelProcessor extends BasicModelProcessor implements Processor
                 || (isNoSort() && (EvalStep.SCORE.equals(this.evalStep) || EvalStep.AUDIT.equals(this.evalStep)))) {
             pigScript = "scripts/EvalScore.pig";
         }
+        if(EvalStep.STAB.equals(this.evalStep) && this.params.containsKey(CHAOS_TYPE) && this.params.containsKey(CHAOS_COLUMNS)) {
+            paramsMap.put(CHAOS_TYPE, this.params.get(CHAOS_TYPE).toString());
+            paramsMap.put(CHAOS_COLUMNS, this.params.get(CHAOS_COLUMNS).toString());
+            pigScript = "scripts/EvalChaosScore.pig";
+        }
+
         try {
             PigExecutor.getExecutor().submitJob(modelConfig, pathFinder.getScriptPath(pigScript), paramsMap,
                     evalConfig.getDataSet().getSource(), confMap, super.pathFinder);
@@ -755,6 +760,123 @@ public class EvalModelProcessor extends BasicModelProcessor implements Processor
                 runEval(evalConfig);
             }
         }
+    }
+
+    private void runStability(List<EvalConfig> evalSetList) throws IOException {
+        // validate the stability config
+        validateStabilityConfig(this.params);
+
+        // do it only once
+        syncDataToHdfs(evalSetList);
+
+        // validation for score column
+        for(EvalConfig evalConfig: evalSetList) {
+            List<String> scoreMetaColumns = evalConfig.getScoreMetaColumns(modelConfig);
+            if(scoreMetaColumns.size() > 5) {
+                LOG.error(
+                        "Starting from 0.10.x, 'scoreMetaColumns' is used for benchmark score columns and limited to at most 5.");
+                LOG.error(
+                        "If meta columns are set in file of 'scoreMetaColumns', please move meta column config to 'eval#dataSet#metaColumnNameFile' part.");
+                LOG.error(
+                        "If 'eval#dataSet#metaColumnNameFile' is duplicated with training 'metaColumnNameFile', you can rename it to another file with different name.");
+                return;
+            }
+        }
+
+        if(Environment.getBoolean(Constants.SHIFU_EVAL_PARALLEL, true) && modelConfig.isMapReduceRunMode()
+                && evalSetList.size() > 1) {
+            // run in parallel
+            int parallelNum = Environment.getInt(Constants.SHIFU_EVAL_PARALLEL_NUM, 5);
+            if(parallelNum <= 0 || parallelNum > 100) {
+                throw new IllegalArgumentException(Constants.SHIFU_EVAL_PARALLEL_NUM
+                        + " in shifuconfig should be in (0, 100], by default it is 5.");
+            }
+
+            int evalSize = evalSetList.size();
+            int mod = evalSize % parallelNum;
+            int batch = evalSize / parallelNum;
+            batch = (mod == 0 ? batch : (batch + 1));
+
+            for(int i = 0; i < batch; i++) {
+                int batchSize = (mod != 0 && i == (batch - 1)) ? mod : parallelNum;
+                // lunch current batch size
+                LOG.info("Starting to run eval score in {}/{} round", (i + 1), batch);
+                final CountDownLatch cdl = new CountDownLatch(batchSize);
+                for(int j = 0; j < batchSize; j++) {
+                    int currentIndex = i * parallelNum + j;
+                    final EvalConfig config = evalSetList.get(currentIndex);
+                    // save tmp models
+                    Thread evalRunThread = new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                runEval(config);
+                            } catch (IOException e) {
+                                LOG.error("Exception in eval:", e);
+                            } catch (Exception e) {
+                                LOG.error("Exception in eval:", e);
+                            }
+                            cdl.countDown();
+                        }
+                    }, config.getName());
+                    // print eval name to log4j console to make each one is easy to be get from logs
+                    evalRunThread.start();
+
+                    // each one sleep 3s to avoid conflict in initialization
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                LOG.info("Starting to wait eval in {}/{} round", (i + 1), batch);
+                // await all threads done
+                try {
+                    cdl.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                LOG.info("Finish eval in {}/{} round", (i + 1), batch);
+            }
+            LOG.info("Finish all eval parallel running with eval size {}.", evalSize);
+        } else {
+            // for old sequential runs
+            for(EvalConfig evalConfig: evalSetList) {
+                runEval(evalConfig);
+            }
+        }
+    }
+
+    private void validateStabilityConfig(Map<String, Object> params) {
+        if(!params.containsKey(CHAOS_TYPE) || !params.containsKey(CHAOS_COLUMNS)) {
+            LOG.error("chaos tpe (-type) and chaos columns(-col) are required");
+            throw new IllegalArgumentException("chaos tpe (-type) and chaos columns(-col) are required");
+        }
+        if(Objects.isNull(ChaosType.fromName(params.get(CHAOS_TYPE).toString()))) {
+            LOG.error("Chaos type {} not supported yet", params.get(CHAOS_TYPE));
+            throw new IllegalArgumentException("Chaos type " + params.get(CHAOS_TYPE) + " does not support yet");
+        }
+        String validColumnNames = getValidColumnNames(params.get(CHAOS_COLUMNS).toString());
+        if(validColumnNames.isEmpty()) {
+            LOG.error("Chaos column {} do not has a valid column name", params.get(CHAOS_COLUMNS));
+            throw new IllegalArgumentException("Chaos column " + params.get(CHAOS_COLUMNS) + " do not has a valid column name");
+        } else {
+            // update the params with the valid columnNames in lower case
+            this.params.put(CHAOS_COLUMNS, validColumnNames);
+        }
+    }
+
+    private String getValidColumnNames(String columnNamesSeparateByComma) {
+        return Arrays.stream(columnNamesSeparateByComma.split(",")).map(String::trim).filter(name -> {
+            for(ColumnConfig columnConfig: this.columnConfigList) {
+                if(columnConfig.getColumnName().equalsIgnoreCase(name)) {
+                    return true;
+                }
+            }
+            LOG.warn("Chaos column value {} is not a valid column name, will be ignored", name);
+            return false;
+        }).map(String::toLowerCase).collect(Collectors.joining(","));
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/ml/shifu/shifu/core/stability/ChaosFactory.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/ChaosFactory.java
@@ -1,0 +1,60 @@
+package ml.shifu.shifu.core.stability;
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+import ml.shifu.shifu.core.stability.algorithm.BaseChaosAlgorithm;
+import ml.shifu.shifu.util.Constants;
+import ml.shifu.shifu.util.Environment;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * ChaosAlgorithmFactory to get chaos factory class by it's name.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public class ChaosFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(ChaosFactory.class);
+    private ChaosType chaosType = ChaosType.fromName(Environment.getProperty(Constants.CHAOS_TYPE));
+    private Set<String> chaosColumnSet = new HashSet<>(Arrays.asList(Environment.getProperty(Constants.CHAOS_COLUMNS).split(",")));
+
+    private ChaosFactory() {
+        LOG.info("ChaosFactory init with chaos type {}: {}", this.chaosType.getName(), this.chaosType.getDescription());
+        LOG.info("Inject chaos type on columns: {}", Environment.getProperty(Constants.CHAOS_COLUMNS));
+    }
+
+    private static class SingletonHolder {
+        private static ChaosFactory instance = new ChaosFactory();
+    }
+
+    /**
+     * Public method to get instance
+     *
+     * @return
+     *         The singleton instance.
+     */
+    public static ChaosFactory getInstance() {
+        return SingletonHolder.instance;
+    }
+
+    private static Map<String, Class<? extends BaseChaosAlgorithm>> algorithmMap = new HashMap<String, Class<? extends BaseChaosAlgorithm>>() {
+        private static final long serialVersionUID = -1080829888400897248L;
+        {
+            Reflections reflections = new Reflections("ml.shifu.shifu.core.stability.algorithm");
+            Set<Class<? extends BaseChaosAlgorithm>> classes = reflections.getSubTypesOf(BaseChaosAlgorithm.class);
+            for(Class<? extends BaseChaosAlgorithm> algorithm: classes) {
+                put(algorithm.getName().toLowerCase(), algorithm);
+            }
+        }
+    };
+
+    public ChaosType getChaosType() {
+        return this.chaosType;
+    }
+
+    public boolean needInjectChaos(ColumnConfig config) {
+        return this.chaosColumnSet.contains(config.getColumnName().toLowerCase());
+    }
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/ChaosFactory.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/ChaosFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability;
 
 import ml.shifu.shifu.container.obj.ColumnConfig;
@@ -55,6 +70,7 @@ public class ChaosFactory {
     }
 
     public boolean needInjectChaos(ColumnConfig config) {
+        LOG.info("Inject chaos for {} use type {}", config.getColumnName(), this.chaosType.getName());
         return this.chaosColumnSet.contains(config.getColumnName().toLowerCase());
     }
 }

--- a/src/main/java/ml/shifu/shifu/core/stability/ChaosType.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/ChaosType.java
@@ -1,0 +1,49 @@
+package ml.shifu.shifu.core.stability;
+
+import ml.shifu.shifu.core.stability.algorithm.ChaosAlgorithm;
+import ml.shifu.shifu.core.stability.algorithm.DeviationChaosAlgorithm;
+import ml.shifu.shifu.core.stability.algorithm.NullValueChaosAlgorithm;
+import ml.shifu.shifu.core.stability.algorithm.RandomChaosAlgorithm;
+
+/**
+ * Enum define different chaos type. For each chaos type, we should consider different logical for both category and
+ * numeric value transfer behaviours.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public enum ChaosType {
+    NULL_VALUE("null", new NullValueChaosAlgorithm(), "return null for category value and return"),
+    RANDOM_VALUE("random", new RandomChaosAlgorithm(), "return random value for numeric, random choose category value from existing category type"),
+    DEVIATION_VALUE("deviation", new DeviationChaosAlgorithm(), "Return deviation value for both category and numeric");
+
+    private String name;
+    private String description;
+    private ChaosAlgorithm chaosAlgorithm;
+
+    ChaosType(String name, ChaosAlgorithm chaosAlgorithm, String description) {
+        this.name = name;
+        this.chaosAlgorithm = chaosAlgorithm;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ChaosAlgorithm getChaosAlgorithm() {
+        return chaosAlgorithm;
+    }
+
+    public static ChaosType fromName(String name) {
+        for(ChaosType chaosType: ChaosType.values()) {
+            if(chaosType.getName().equalsIgnoreCase(name)) {
+                return chaosType;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/ChaosType.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/ChaosType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability;
 
 import ml.shifu.shifu.core.stability.algorithm.ChaosAlgorithm;

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/BaseChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/BaseChaosAlgorithm.java
@@ -1,0 +1,22 @@
+package ml.shifu.shifu.core.stability.algorithm;
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+
+/**
+ * Base implementation of ChaosAlgorithm, all sub class need to implement generate chaos value both for category
+ * and numeric data.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public abstract class BaseChaosAlgorithm implements ChaosAlgorithm {
+    @Override
+    public String generateChaosValue(String originValue, ColumnConfig config) {
+        if(config.isCategorical()) {
+            return generateCategoryChaosValue(originValue, config);
+        }
+        return generateNumericChaosValue(originValue, config);
+    }
+
+    abstract String generateCategoryChaosValue(String originValue, ColumnConfig config);
+    abstract String generateNumericChaosValue(String originValue, ColumnConfig config);
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/BaseChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/BaseChaosAlgorithm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability.algorithm;
 
 import ml.shifu.shifu.container.obj.ColumnConfig;

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/ChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/ChaosAlgorithm.java
@@ -1,0 +1,21 @@
+package ml.shifu.shifu.core.stability.algorithm;
+
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+
+/**
+ * ChaosAlgorithm interface.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public interface ChaosAlgorithm {
+
+    /**
+     * Generate chaos value from origin value.
+     *
+     * @param originValue  the origin value
+     * @param config the column config contain stats info
+     * @return chaos value
+     */
+    String generateChaosValue(String originValue, ColumnConfig config);
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/ChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/ChaosAlgorithm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability.algorithm;
 
 

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/DeviationChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/DeviationChaosAlgorithm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability.algorithm;
 
 import ml.shifu.shifu.container.obj.ColumnConfig;

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/DeviationChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/DeviationChaosAlgorithm.java
@@ -1,0 +1,23 @@
+package ml.shifu.shifu.core.stability.algorithm;
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+
+/**
+ * DeviationChaosAlgorithm stand for all the value being deviated.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public class DeviationChaosAlgorithm extends BaseChaosAlgorithm {
+    @Override
+    String generateCategoryChaosValue(String originValue, ColumnConfig config) {
+        if(config.getBinCategory().size() == 0) {
+            return originValue;
+        }
+        return config.getBinCategory().get(config.getBinCategory().size() - 1);
+    }
+
+    @Override
+    String generateNumericChaosValue(String originValue, ColumnConfig config) {
+        return String.valueOf(Double.parseDouble(originValue) + config.getColumnStats().getMax());
+    }
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/NullValueChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/NullValueChaosAlgorithm.java
@@ -1,0 +1,21 @@
+package ml.shifu.shifu.core.stability.algorithm;
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+
+/**
+ * NullValueChaosAlgorithm return null for category value and 0 for numeric value.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public class NullValueChaosAlgorithm extends BaseChaosAlgorithm {
+
+    @Override
+    String generateCategoryChaosValue(String originValue, ColumnConfig config) {
+        return null;
+    }
+
+    @Override
+    String generateNumericChaosValue(String originValue, ColumnConfig config) {
+        return "0";
+    }
+}

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/NullValueChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/NullValueChaosAlgorithm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability.algorithm;
 
 import ml.shifu.shifu.container.obj.ColumnConfig;

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/RandomChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/RandomChaosAlgorithm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability.algorithm;
 
 import ml.shifu.shifu.container.obj.ColumnConfig;

--- a/src/main/java/ml/shifu/shifu/core/stability/algorithm/RandomChaosAlgorithm.java
+++ b/src/main/java/ml/shifu/shifu/core/stability/algorithm/RandomChaosAlgorithm.java
@@ -1,0 +1,25 @@
+package ml.shifu.shifu.core.stability.algorithm;
+
+import ml.shifu.shifu.container.obj.ColumnConfig;
+
+import java.util.Random;
+
+/**
+ * Generate random value for both category and numeric.
+ *
+ * @author Wu Devin (haifwu@paypal.com)
+ */
+public class RandomChaosAlgorithm extends BaseChaosAlgorithm {
+    private static Random random = new Random(System.currentTimeMillis());
+
+    @Override
+    String generateCategoryChaosValue(String originValue, ColumnConfig config) {
+        int cnt = config.getBinCategory().size();
+        return config.getBinCategory().get(random.nextInt(cnt));
+    }
+
+    @Override
+    String generateNumericChaosValue(String originValue, ColumnConfig config) {
+        return String.valueOf(random.nextDouble());
+    }
+}

--- a/src/main/java/ml/shifu/shifu/udf/EvalScoreUDF.java
+++ b/src/main/java/ml/shifu/shifu/udf/EvalScoreUDF.java
@@ -151,6 +151,13 @@ public class EvalScoreUDF extends AbstractEvalUDF<Tuple> {
         this(source, pathModelConfig, pathColumnConfig, evalSetName, Integer.toString(Scorer.DEFAULT_SCORE_SCALE));
     }
 
+    public EvalScoreUDF(String source, String pathModelConfig, String pathColumnConfig, String evalSetName,
+                        String scale, String chaosType, String chaosColumns) throws IOException {
+        this(source, pathModelConfig, pathColumnConfig, evalSetName, scale);
+        Environment.setProperty(Constants.CHAOS_TYPE, chaosType);
+        Environment.setProperty(Constants.CHAOS_COLUMNS, chaosColumns);
+    }
+
     @SuppressWarnings("unchecked")
     public EvalScoreUDF(String source, String pathModelConfig, String pathColumnConfig, String evalSetName,
             String scale) throws IOException {

--- a/src/main/java/ml/shifu/shifu/util/CommonUtils.java
+++ b/src/main/java/ml/shifu/shifu/util/CommonUtils.java
@@ -697,13 +697,15 @@ public final class CommonUtils {
         return headerList.toArray(new String[0]);
     }
 
-    /**
-     * Get the unique name.
-     *
-     * @return name if name set doesn't contains it. If name exist in name set, it will check name_1, name_2, name_n to find one which doesn't
-     * exist in the set.
-     */
-    public static String getUniqueName(Set<String> nameSet, String name) {
+  /**
+   * Get the unique name.
+   *
+   * @param nameSet name set
+   * @param name the origin name
+   * @return name if name set doesn't contains it. If name exist in name set, it will check name_1,
+   *     name_2, name_n to find one which doesn't * exist in the set.
+   */
+  public static String getUniqueName(Set<String> nameSet, String name) {
         if (nameSet == null || name == null) {
             return name;
         }

--- a/src/main/java/ml/shifu/shifu/util/Constants.java
+++ b/src/main/java/ml/shifu/shifu/util/Constants.java
@@ -378,4 +378,10 @@ public interface Constants {
     
     public static final String UTF_8 = "utf-8";
 
+    /**
+     * For chaos config
+     */
+    public static final String CHAOS_TYPE = "type";
+    public static final String CHAOS_COLUMNS = "cols";
+
 }

--- a/src/main/java/ml/shifu/shifu/util/HDFSUtils.java
+++ b/src/main/java/ml/shifu/shifu/util/HDFSUtils.java
@@ -71,6 +71,7 @@ public final class HDFSUtils {
 
     /**
      * Get HDFS FileSystem.
+     * @return file system
      */
     public static FileSystem getFS() {
         return getFS(null);

--- a/src/main/java/ml/shifu/shifu/util/NormalizationUtils.java
+++ b/src/main/java/ml/shifu/shifu/util/NormalizationUtils.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import ml.shifu.shifu.core.stability.ChaosFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.encog.ml.data.MLDataPair;
 import org.encog.ml.data.basic.BasicMLData;
@@ -119,7 +120,7 @@ public class NormalizationUtils {
             } else {
                 if(!noVarSel) {
                     if(config != null && !config.isMeta() && !config.isTarget() && config.isFinalSelect()) {
-                        String val = getNSVariableVal(rawNsDataMap, key);
+                        String val = getChaosValue(getNSVariableVal(rawNsDataMap, key), config);
                         if(CommonUtils.isTreeModel(alg) && config.isCategorical()) {
                             Integer index = binCategoryMap.get(config.getColumnNum()).get(val == null ? "" : val);
                             if(index == null) {
@@ -140,7 +141,7 @@ public class NormalizationUtils {
                     }
                 } else {
                     if(!config.isMeta() && !config.isTarget() && CommonUtils.isGoodCandidate(config, hasCandidates)) {
-                        String val = getNSVariableVal(rawNsDataMap, key);
+                        String val = getChaosValue(getNSVariableVal(rawNsDataMap, key), config);
                         if(CommonUtils.isTreeModel(alg) && config.isCategorical()) {
                             Integer index = binCategoryMap.get(config.getColumnNum()).get(val == null ? "" : val);
                             if(index == null) {
@@ -163,6 +164,13 @@ public class NormalizationUtils {
             }
         }
         return inputList;
+    }
+
+    private static String getChaosValue(String originValue, ColumnConfig config) {
+        if(ChaosFactory.getInstance().needInjectChaos(config)) {
+            return ChaosFactory.getInstance().getChaosType().getChaosAlgorithm().generateChaosValue(originValue, config);
+        }
+        return originValue;
     }
 
     /**

--- a/src/main/pig/EvalChaosScore.pig
+++ b/src/main/pig/EvalChaosScore.pig
@@ -1,0 +1,39 @@
+/**
+ * Copyright [2012-2014] PayPal Software Foundation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+REGISTER $path_jar;
+
+SET pig.exec.reducers.max 999;
+SET pig.exec.reducers.bytes.per.reducer 536870912;
+SET mapred.job.queue.name $queue_name;
+SET job.name 'Shifu Evaluation Score: $data_set';
+SET mapred.child.java.opts -Xmx1G;
+SET mapred.child.ulimit 2.5G;
+SET mapred.reduce.slowstart.completed.maps 0.6;
+SET mapred.map.tasks.speculative.execution true;
+SET mapred.reduce.tasks.speculative.execution true;
+SET mapreduce.map.speculative true;
+SET mapreduce.reduce.speculative true;
+
+DEFINE IsDataFilterOut  ml.shifu.shifu.udf.PurifyDataUDF('$source_type', '$path_model_config', '$path_column_config', '$eval_set_name');
+DEFINE EvalScore        ml.shifu.shifu.udf.EvalScoreUDF('$source_type', '$path_model_config', '$path_column_config', '$eval_set_name', '$scale', '$type', '$cols');
+
+raw = LOAD '$pathEvalRawData' USING PigStorage('$delimiter', '-noschema');
+raw = FILTER raw BY IsDataFilterOut(*);
+
+evalScore = FOREACH raw GENERATE FLATTEN(EvalScore(*));
+evalScore = FILTER evalScore BY $0 IS NOT NULL;
+
+STORE evalScore INTO '$pathEvalScore' USING PigStorage('$output_delimiter', '-schema');

--- a/src/test/java/ml/shifu/shifu/core/dtrain/layer/activation/ActivationFactoryTest.java
+++ b/src/test/java/ml/shifu/shifu/core/dtrain/layer/activation/ActivationFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ml.shifu.shifu.core.dtrain.layer.activation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ActivationFactoryTest {
+
+    @Test
+    public void testGetActivation() {
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("Relu").getClass(), ReLU.class);
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("LeakyReLU").getClass(), LeakyReLU.class);
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("Log").getClass(), Log.class);
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("Sigmoid").getClass(), Sigmoid.class);
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("Swish").getClass(), Swish.class);
+        Assert.assertEquals(ActivationFactory.getInstance().getActivation("notExist").getClass(), ReLU.class);
+    }
+}

--- a/src/test/java/ml/shifu/shifu/core/stability/ChaosFactoryTest.java
+++ b/src/test/java/ml/shifu/shifu/core/stability/ChaosFactoryTest.java
@@ -1,0 +1,16 @@
+package ml.shifu.shifu.core.stability;
+
+
+import ml.shifu.shifu.util.Constants;
+import ml.shifu.shifu.util.Environment;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChaosFactoryTest {
+    @Test
+    public void testGetChaosType() {
+        Environment.setProperty(Constants.CHAOS_TYPE, "null");
+        Environment.setProperty(Constants.CHAOS_COLUMNS, "");
+        Assert.assertEquals(ChaosFactory.getInstance().getChaosType().getName(), ChaosType.NULL_VALUE.getName());
+    }
+}

--- a/src/test/java/ml/shifu/shifu/core/stability/ChaosFactoryTest.java
+++ b/src/test/java/ml/shifu/shifu/core/stability/ChaosFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability;
 
 

--- a/src/test/java/ml/shifu/shifu/core/stability/ChaosTypeTest.java
+++ b/src/test/java/ml/shifu/shifu/core/stability/ChaosTypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2013-2021] PayPal Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ml.shifu.shifu.core.stability;
 
 import ml.shifu.shifu.core.stability.algorithm.DeviationChaosAlgorithm;

--- a/src/test/java/ml/shifu/shifu/core/stability/ChaosTypeTest.java
+++ b/src/test/java/ml/shifu/shifu/core/stability/ChaosTypeTest.java
@@ -1,0 +1,23 @@
+package ml.shifu.shifu.core.stability;
+
+import ml.shifu.shifu.core.stability.algorithm.DeviationChaosAlgorithm;
+import ml.shifu.shifu.core.stability.algorithm.NullValueChaosAlgorithm;
+import ml.shifu.shifu.core.stability.algorithm.RandomChaosAlgorithm;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChaosTypeTest {
+    @Test
+    public void testGetChaosAlgorithm() {
+        Assert.assertTrue(ChaosType.NULL_VALUE.getChaosAlgorithm() instanceof NullValueChaosAlgorithm);
+        Assert.assertTrue(ChaosType.RANDOM_VALUE.getChaosAlgorithm() instanceof RandomChaosAlgorithm);
+        Assert.assertTrue(ChaosType.DEVIATION_VALUE.getChaosAlgorithm() instanceof DeviationChaosAlgorithm);
+
+    }
+
+    @Test
+    public void testFromName() {
+        Assert.assertEquals(ChaosType.fromName("null").getName(), "null");
+        Assert.assertNull(ChaosType.fromName("not_exist"));
+    }
+}


### PR DESCRIPTION
Running comand example: 
 ../shifu eval Eval1 -stab -type random -cols "column_3,column_4"

the left screen shows the origin gain char, and the right shows the gain char injected random chaos on column_3 and column_4.
![image](https://user-images.githubusercontent.com/3108520/104121348-57412480-5378-11eb-8aaa-662c7ea4c09c.png)
