### PR TITLE
Fix split issue for CategoricalBinning

### DIFF
--- a/src/main/java/ml/shifu/shifu/core/binning/CategoricalBinning.java
+++ b/src/main/java/ml/shifu/shifu/core/binning/CategoricalBinning.java
@@ -177,7 +177,7 @@ public class CategoricalBinning extends AbstractBinning<String> {
             categoricalVals.clear();
         }
 
-        String[] objStrArr = CommonUtils.split(objValStr, Character.toString(FIELD_SEPARATOR));
+        String[] objStrArr = objValStr.split(Character.toString(FIELD_SEPARATOR), 7);
         this.isValid = Boolean.valueOf(objStrArr[4]);
         if(objStrArr.length > 5 && StringUtils.isNotBlank(objStrArr[5])) {
             String[] elements = CommonUtils.split(objStrArr[5], Character.toString(SETLIST_SEPARATOR));
@@ -205,8 +205,8 @@ public class CategoricalBinning extends AbstractBinning<String> {
     public String objToString() {
         try {
             return super.objToString() + Character.toString(FIELD_SEPARATOR) + Boolean.toString(isValid)
-                    + Character.toString(FIELD_SEPARATOR) + StringUtils.join(categoricalVals, SETLIST_SEPARATOR)
-                    + Character.toString(FIELD_SEPARATOR) + Base64Utils.base64EncodeFromBytes(this.hyper.getBytes());
+                    + Character.toString(FIELD_SEPARATOR) + Base64Utils.base64EncodeFromBytes(this.hyper.getBytes())
+                    + Character.toString(FIELD_SEPARATOR) + StringUtils.join(categoricalVals, SETLIST_SEPARATOR);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This fix is for categorical binning separator.

The issue:
1. The binning string contains 7 fields currently: `c1|c2|...|c7` (the separator is 0x0001 instead of |, I use | for better understanding).
2. The value of `c6` is categoricalVals which has separator charactor for some inputs: `c6=c6_1|c6_2`.
3. At this point, the fields become `c1|c2|...|c6_1|c6_2|c7`. When we split the fields, we will get 8 fields and the fields[5] is c6_1 and fields[6] is c6_2 which is wrong.

Fix:
1. Change the order to `c1|c2|c3|c4|c5|c7|c6`, because only c6 may has separator charactor.
2. We will have this order in above example: `c1|c2|c3|c4|c5|c7|c6_1|c6_2`.
2. Split the binning string up to 7 fields. We will have these fields: fields[5] is c7 and fields[6] is c6_1|c6_2.